### PR TITLE
Add Python3 PyUnicode_FromStringAndSize(x, len)

### DIFF
--- a/wiringpi_wrap.c
+++ b/wiringpi_wrap.c
@@ -730,6 +730,7 @@ SWIG_UnpackDataName(const char *c, void *ptr, size_t sz, const char *name) {
 #define PyInt_FromSize_t(x) PyLong_FromSize_t(x)
 #define PyString_Check(name) PyBytes_Check(name)
 #define PyString_FromString(x) PyUnicode_FromString(x)
+#define PyString_FromStringAndSize(x, len) PyUnicode_FromStringAndSize(x, len)
 #define PyString_Format(fmt, args)  PyUnicode_Format(fmt, args)
 #define PyString_AsString(str) PyBytes_AsString(str)
 #define PyString_Size(str) PyBytes_Size(str)	


### PR DESCRIPTION
A definition is missing in the wrapper to make this fully python 3 compatible
